### PR TITLE
Bump to tor-binary v0.4.5.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.berndpruenster.netlayer</groupId>
     <artifactId>parent</artifactId>
-    <version>0.6.8.3</version>
+    <version>0.6.8.4</version>
     <packaging>pom</packaging>
 
     <name>Netlayer</name>
@@ -17,7 +17,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <!-- Maven plugins -->
         <maven-compiler-plugin.version>3.7.0</maven-compiler-plugin.version>
-        <tor-binary.version>a4b868a</tor-binary.version>
+        <tor-binary.version>b9c6227</tor-binary.version>
     </properties>
 
     <modules>

--- a/tor.external/pom.xml
+++ b/tor.external/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.berndpruenster.netlayer</groupId>
         <artifactId>parent</artifactId>
-        <version>0.6.8.3</version>
+        <version>0.6.8.4</version>
     </parent>
 
     <artifactId>tor.external</artifactId>

--- a/tor.native/pom.xml
+++ b/tor.native/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.berndpruenster.netlayer</groupId>
         <artifactId>parent</artifactId>
-        <version>0.6.8.3</version>
+        <version>0.6.8.4</version>
     </parent>
 
     <artifactId>tor.native</artifactId>

--- a/tor/pom.xml
+++ b/tor/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.berndpruenster.netlayer</groupId>
         <artifactId>parent</artifactId>
-        <version>0.6.8.3</version>
+        <version>0.6.8.4</version>
     </parent>
 
     <artifactId>tor</artifactId>


### PR DESCRIPTION
Bump tor-binary dependency to version built on tor-browser v10.0.14 / tor-binary v0.4.5.7