### PR TITLE
Workaround for missing jitpack builds

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,24 @@
         <dependency>
             <groupId>com.github.ravn</groupId>
             <artifactId>jsocks</artifactId>
-            <version>567e1cd</version>
+            <!--
+                Shorter version of the commit ID, to reference a separate jitpack artefact build for the same commit
+
+                Previously, the commit ID 567e1cd of the artefact was used here, which pointed to the jitpack build:
+                https://jitpack.io/com/github/ravn/jsocks/567e1cd/build.log
+
+                However, that specific build is now missing on jitpack, even though nothing changed in the reference git repo:
+                https://github.com/ravn/jsocks
+                (last commit is still 567e1cd)
+
+                Using a shorter version of the same commit ID tricks jitpack into thinking its a new build:
+                https://jitpack.io/com/github/ravn/jsocks/567e1/build.log
+                (jitpack build triggered on 18.05.2021)
+                (looks like someone else used this workaround already in May to re-trigger the build in jitpack)
+
+                So, by using a shorter version of the dependency commit ID, we work around the missing version of the artefact on jitpack
+             -->
+            <version>567e1</version>
         </dependency>
         <dependency>
             <groupId>io.github.microutils</groupId>

--- a/tor/pom.xml
+++ b/tor/pom.xml
@@ -23,7 +23,16 @@
         <dependency>
             <groupId>com.github.JesusMcCloud</groupId>
             <artifactId>jtorctl</artifactId>
-            <version>1.5</version>
+            <!--
+                Recently the v1.5 build of the artefact went missing from jitpack:
+                https://jitpack.io/com/github/JesusMcCloud/jtorctl/1.5/build.log
+
+                We now reference the commit ID of the 1.5 version of the artefact
+                https://github.com/JesusMcCloud/jtorctl/releases/tag/1.5
+                which results in a separate jitpack build of the same dep. (equivalent to re-building the dependency)
+                https://jitpack.io/com/github/JesusMcCloud/jtorctl/9b5ba2036b/build.log
+             -->
+            <version>9b5ba2036b</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
Reference artefacts by commit ID (or slightly shorter commit ID) to trigger jitpack to use a separate build for these artefacts.