### PR TITLE
Jitpack cannot resolve dependencies if defined as

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
             <version>${kotlin.version}</version>
         </dependency>
         <dependency>
-            <groupId>com.github.bisq-network.jsocks</groupId>
+            <groupId>com.github.bisq-network</groupId>
             <artifactId>jsocks</artifactId>
             <!-- v0.0.2 -->
             <version>43b004b5bcc468fb1213767853e1d8a54fd4a359</version>

--- a/tor/pom.xml
+++ b/tor/pom.xml
@@ -21,7 +21,7 @@
             <version>${tor-binary.version}</version>
         </dependency>
         <dependency>
-            <groupId>com.github.bisq-network.jtorctl</groupId>
+            <groupId>com.github.bisq-network</groupId>
             <artifactId>jtorctl</artifactId>
             <!-- v1.5 -->
             <version>b2a172f44edcd8deaa5ed75d936dcbb007f0d774</version>


### PR DESCRIPTION
```
 <groupId>com.github.bisq-network.jsocks</groupId>
            <artifactId>jsocks</artifactId>
```
But if with `<groupId>com.github.bisq-network</groupId>` it works. No idea why...