### PR TITLE
allow non-daemon Tor for linux/macos based on torrc configuration

### DIFF
--- a/tor.native/src/main/kotlin/org/berndpruenster/netlayer/tor/TorContext.kt
+++ b/tor.native/src/main/kotlin/org/berndpruenster/netlayer/tor/TorContext.kt
@@ -96,6 +96,8 @@ class Torrc @Throws(IOException::class) internal constructor(defaults: InputStre
             return ByteArrayInputStream(outputStream.toByteArray())
         }
 
+    internal val runAsDaemon = rc.getOrDefault("RunAsDaemon", "0").toBoolean()
+
     companion object {
         @Throws(IOException::class)
         private fun parse(src: InputStream?): LinkedHashMap<String, String>? {
@@ -168,6 +170,7 @@ abstract class TorContext @Throws(IOException::class) protected constructor(val 
     internal val torrcFile = File(workingDirectory, FILE_TORRC)
     internal val torExecutableFile get() = File(workingDirectory, torExecutableFileName)
     internal val cookieFile = File(workingDirectory, FILE_AUTH_COOKIE)
+    private var runAsDaemon: Boolean = false
 
     @Throws(IOException::class)
     open fun installFiles() {
@@ -219,8 +222,11 @@ abstract class TorContext @Throws(IOException::class) protected constructor(val 
         getByName(FILE_TORRC).use { str ->
             Torrc(str, overrides).inputStream.use { rc ->
                 getByName(FILE_TORRC_DEFAULTS).use {
-                    Torrc(rc, it).inputStream.use {
-                        cleanInstallFile(it, torrcFile)
+                    runAsDaemon = with(Torrc(rc, it)) {
+                        this.inputStream.use {
+                            cleanInstallFile(it, torrcFile)
+                        }
+                        this.runAsDaemon
                     }
                 }
             }
@@ -347,7 +353,7 @@ abstract class TorContext @Throws(IOException::class) protected constructor(val 
             // This does create a condition where the process has exited due to
             // a problem but we should hopefully
             // detect that when we try to use the control connection.
-            if (OsType.current != OsType.WIN) {
+            if (OsType.current != OsType.WIN && runAsDaemon) {
                 val exit = torProcess.waitFor()
                 torProcess = null
                 if (exit != 0) {


### PR DESCRIPTION
This PR adds a possibility to run Tor in non-Daemon mode (`RunAsDaemon 0` in torrc overrides).

Beware:
This feature will not work without fixing `overrides` in https://github.com/bisq-network/netlayer/pull/13, since it is required to override the configuration.

I created this PR separately since it is a separate feature and i need https://github.com/bisq-network/netlayer/pull/13 more than this PR.