### PR TITLE
Whonix only: Bind/listen on 0.0.0.0 instead of 127.0.0.1

### DIFF
--- a/tor/src/main/kotlin/org/berndpruenster/netlayer/tor/Tor.kt
+++ b/tor/src/main/kotlin/org/berndpruenster/netlayer/tor/Tor.kt
@@ -52,6 +52,7 @@ import java.security.MessageDigest
 
 
 const val LOCAL_IP = "127.0.0.1"
+const val EXTERNAL_IP = "0.0.0.0"
 private const val LOCAL_ADDR_FRAGMENT = "\"" + LOCAL_IP + ":"
 private const val NET_LISTENERS_SOCKS = "net/listeners/socks"
 

--- a/tor/src/main/kotlin/org/berndpruenster/netlayer/tor/TorSockets.kt
+++ b/tor/src/main/kotlin/org/berndpruenster/netlayer/tor/TorSockets.kt
@@ -21,6 +21,7 @@ import com.runjva.sourceforge.jsocks.protocol.SocksSocket
 import java.io.IOException
 import java.io.InputStream
 import java.io.OutputStream
+import java.io.*
 import java.net.*
 import java.nio.channels.SocketChannel
 import java.util.*
@@ -190,8 +191,19 @@ class HiddenServiceSocket @JvmOverloads constructor(internalPort: Int,
         val (name, handler) = mgr.publishHiddenService(hiddenServiceDir, hiddenServicePort, internalPort)
         serviceName = name
         socketAddress = HiddenServiceSocketAddress(name, hiddenServicePort)
-        bind(InetSocketAddress(LOCAL_IP, internalPort))
+        bind(InetSocketAddress(if (isWhonixWorkstation()) EXTERNAL_IP else LOCAL_IP, internalPort))
         handler.attachReadyListeners(this, listeners)
+    }
+
+    private fun isWhonixWorkstation() : Boolean {
+        val testFile1 = File("/usr/share/whonix", "marker")
+        val testFile2 = File("/usr/share/anon-ws-base-files", "workstation")
+        return if (testFile1.exists() && testFile2.exists()) {
+            logger?.info("Whonix WS detected, binding to external interface.")
+            true
+        } else {
+            false
+        }
     }
 
     fun addReadyListener(listener: (socket: HiddenServiceSocket) -> Unit) {


### PR DESCRIPTION
Fixes https://github.com/bisq-network/bisq/issues/6149
2nd attempt, previous was #5.  Now detects Whonix using [their published guidelines](https://www.whonix.org/wiki/Dev/Project_friendly_applications_best_practices#Programmatically_Detecting_Whonix_%E2%84%A2) and acts accordingly.

This PR is necessary for Whonix users because currently their open offers are unreachable by takers.  This causes confusion, support queries, and missed trading opportunities.

---

Setups which use an external Tor on a different VM (such as Whonix) have a problem that they never get incoming connections.  Bisq looks like it is running ok, but peers attempting to connect get rejected.  This means that offers cannot be taken, they are shown the error "Maker is offline".

Bisq can be run in two different modes: Native Tor and External.  Native is the default configuration, where Bisq spawns its local copy of the Tor binary.  In External mode Bisq connects to Tor service.  If Tor service is on a different machine, it cannot connect back to 127.0.0.1 on the workstation.


Solution is to bind/listen on `0.0.0.0` **when using Whonix WS** as suggested by @JeremyRand in https://github.com/bisq-network/bisq/issues/6149. 

Ref: https://unix.stackexchange.com/questions/419880/connecting-to-ip-0-0-0-0-succeeds-how-why?answertab=scoredesc#tab-top




**Diagram showing the problem of binding to 127.0.0.1:**

![image](https://user-images.githubusercontent.com/47253594/163740110-a1254865-bf5d-4ffb-86a9-533fe33d84cd.png)


### Testing:

**Test that Bisq runs ok in Native mode.**
Start bisq with the normal command line options.  Perform Tests shown below.

**Test that Bisq runs ok in External mode.**
Setup & run Tor service.  Control port should be accessible from the workstation.
Start bisq with the following options included:   `--torControlPort=9051 --torControlPassword="notrequired"`
Perform Tests shown below.


**Tests**

- Verify that Bisq starts up and syncs correctly.
- Verify that Bisq shows the correct offer book.
- Verify that your open offers can be taken by another client on the network.



---

While checking this issue, I wrote simple standalone apps [DemoTorReceiver / DemoTorSender](https://github.com/jmacxx/WIP/tree/master/tor) that send and receive a hello world message using the same libraries that Bisq uses.  There's an example run shown in the [readme](https://github.com/jmacxx/WIP/blob/master/tor/README.md).  I found them useful for understanding netlayer, and simplifying / testing the problem.

I have tested this fix on Whonix, and verified that offers are able to be taken.
