### PR TITLE
Allow empty string as the native hidden-service directory

### DIFF
--- a/tor.native/src/main/kotlin/org/berndpruenster/netlayer/tor/NativeTor.kt
+++ b/tor.native/src/main/kotlin/org/berndpruenster/netlayer/tor/NativeTor.kt
@@ -118,6 +118,7 @@ class NativeTor @JvmOverloads @Throws(TorCtlException::class) constructor(workin
         }
     }
 
+    @Throws(IOException::class)
     override fun preprocessHsDirName(hsDirName: String): File {
         return context.getHiddenServiceDirectory(hsDirName)
     }

--- a/tor.native/src/main/kotlin/org/berndpruenster/netlayer/tor/TorContext.kt
+++ b/tor.native/src/main/kotlin/org/berndpruenster/netlayer/tor/TorContext.kt
@@ -314,15 +314,21 @@ abstract class TorContext @Throws(IOException::class) protected constructor(val 
 
     abstract fun getByName(fileName: String): InputStream
 
+    @Throws(IOException::class)
     fun getHiddenServiceDirectory(hsDir: String): File {
-        require(hsDir.isNotBlank() && hsDir.indexOfAny(LINE_BREAKS) < 0) {
-            "Hidden service directory name must be a non-empty single line"
+        val hiddenServiceRoot = File(workingDirectory, DIR_HS_ROOT).canonicalFile
+        if (hsDir.isEmpty()) {
+            // Bisq NewTor historically passes an empty hidden-service directory name.
+            // Keep that API contract by using the default hidden-service root itself.
+            return hiddenServiceRoot
+        }
+        if (hsDir.isBlank() || hsDir.indexOfAny(LINE_BREAKS) >= 0) {
+            throw IOException("Hidden service directory name must be empty or a non-blank single line")
         }
 
-        val hiddenServiceRoot = File(workingDirectory, DIR_HS_ROOT).canonicalFile
         val hiddenServiceDirectory = File(hiddenServiceRoot, hsDir).canonicalFile
-        require(hiddenServiceDirectory.toPath().startsWith(hiddenServiceRoot.toPath()) && hiddenServiceDirectory != hiddenServiceRoot) {
-            "Hidden service directory must stay under $hiddenServiceRoot"
+        if (!hiddenServiceDirectory.toPath().startsWith(hiddenServiceRoot.toPath()) || hiddenServiceDirectory == hiddenServiceRoot) {
+            throw IOException("Hidden service directory '$hsDir' must resolve below $hiddenServiceRoot")
         }
         return hiddenServiceDirectory
     }

--- a/tor.native/src/test/kotlin/org/berndpruenster/netlayer/tor/TorContextTest.kt
+++ b/tor.native/src/test/kotlin/org/berndpruenster/netlayer/tor/TorContextTest.kt
@@ -1,0 +1,71 @@
+package org.berndpruenster.netlayer.tor
+
+import java.io.File
+import java.io.IOException
+import java.nio.file.Files
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+class TorContextTest {
+
+    @Test
+    fun emptyHiddenServiceDirectoryUsesRootDirectory() = withNativeContext { context, workingDirectory ->
+        val expected = File(workingDirectory, "hiddenservice").canonicalFile
+
+        assertEquals(expected, context.getHiddenServiceDirectory(""))
+    }
+
+    @Test
+    fun namedHiddenServiceDirectoryStaysUnderRootDirectory() = withNativeContext { context, workingDirectory ->
+        val expected = File(File(workingDirectory, "hiddenservice"), "bisq").canonicalFile
+
+        assertEquals(expected, context.getHiddenServiceDirectory("bisq"))
+    }
+
+    @Test
+    fun whitespaceOnlyHiddenServiceDirectoryIsRejected() = withNativeContext { context, _ ->
+        val exception = assertFailsWith<IOException> {
+            context.getHiddenServiceDirectory(" ")
+        }
+
+        assertTrue(exception.message!!.contains("empty or a non-blank single line"))
+    }
+
+    @Test
+    fun multilineHiddenServiceDirectoryIsRejected() = withNativeContext { context, _ ->
+        val exception = assertFailsWith<IOException> {
+            context.getHiddenServiceDirectory("bisq\nservice")
+        }
+
+        assertTrue(exception.message!!.contains("empty or a non-blank single line"))
+    }
+
+    @Test
+    fun hiddenServiceDirectoryTraversalIsRejected() = withNativeContext { context, _ ->
+        val exception = assertFailsWith<IOException> {
+            context.getHiddenServiceDirectory("../outside")
+        }
+
+        assertTrue(exception.message!!.contains("must resolve below"))
+    }
+
+    @Test
+    fun nonEmptyHiddenServiceDirectoryCannotResolveToRootDirectory() = withNativeContext { context, _ ->
+        val exception = assertFailsWith<IOException> {
+            context.getHiddenServiceDirectory(".")
+        }
+
+        assertTrue(exception.message!!.contains("must resolve below"))
+    }
+
+    private fun withNativeContext(block: (NativeContext, File) -> Unit) {
+        val workingDirectory = Files.createTempDirectory("netlayer-hidden-service").toFile()
+        try {
+            block(NativeContext(workingDirectory, null), workingDirectory)
+        } finally {
+            workingDirectory.deleteRecursively()
+        }
+    }
+}

--- a/tor/src/main/kotlin/org/berndpruenster/netlayer/tor/Tor.kt
+++ b/tor/src/main/kotlin/org/berndpruenster/netlayer/tor/Tor.kt
@@ -250,6 +250,7 @@ abstract class Tor @Throws(TorCtlException::class) protected constructor() {
     @JvmOverloads
     fun getProxy(proxyHost: String, streamID: String? = null): Socks5Proxy = Tor.getProxy(proxyHost, control.proxyPort, streamID)
 
+    @Throws(IOException::class)
     abstract fun preprocessHsDirName(hsDirName: String) : File
 
     /**
@@ -267,7 +268,13 @@ abstract class Tor @Throws(TorCtlException::class) protected constructor() {
     @Throws(IOException::class, TorCtlException::class)
     fun publishHiddenService(hsDirName: String, hiddenServicePort: Int, localPort: Int): HsContainer {
 
-        val hiddenServiceDirectory = preprocessHsDirName(hsDirName)
+        val hiddenServiceDirectory = try {
+            preprocessHsDirName(hsDirName)
+        } catch (e: IOException) {
+            throw e
+        } catch (e: IllegalArgumentException) {
+            throw IOException("Invalid hidden service directory '$hsDirName'", e)
+        }
         val hostnameFile = File(hiddenServiceDirectory, FILE_HOSTNAME)
         val keyFile = File(hiddenServiceDirectory, FILE_PRIVATE_KEY)
         rejectSymbolicLink(hostnameFile)


### PR DESCRIPTION
Allow empty string as the native hidden-service directory


"" now resolves to the native hidden-service root, preserving Bisq NewTor behavior, while non-empty names still must resolve below that root. Invalid names now throw IOException with clearer messages instead of unchecked require failures. See TorContext.kt and Tor.kt. I also added focused coverage in TorContextTest.kt for empty names, normal names, whitespace, multiline values, traversal, and ".". 